### PR TITLE
Potential fix for code scanning alert no. 17: Use of externally-controlled format string

### DIFF
--- a/packages/server/src/engine/spawner.ts
+++ b/packages/server/src/engine/spawner.ts
@@ -700,7 +700,10 @@ export class ClaudeCodeSpawner extends EventEmitter {
       // to the inline arg. It may still E2BIG on a huge value, but that matches
       // the pre-existing behavior rather than introducing a new failure mode.
       console.warn(
-        `${this.logLabel()} could not write ${label} temp file (${file}) — passing inline:`,
+        '%s could not write %s temp file (%s) — passing inline:',
+        this.logLabel(),
+        label,
+        file,
         err instanceof Error ? err.message : err,
       )
       return null


### PR DESCRIPTION
Potential fix for [https://github.com/rondoflow/rondoflow/security/code-scanning/17](https://github.com/rondoflow/rondoflow/security/code-scanning/17)

Use a constant format string as the first argument to `console.warn`, and pass dynamic values (including potentially untrusted ones) as `%s`/`%o` substitution arguments. This prevents user-controlled `%` sequences from being interpreted as format directives.

Best fix (minimal behavior change) in `packages/server/src/engine/spawner.ts` around `writePromptFile` catch block (lines ~702–705): replace the template-literal first argument with a static format string and pass `this.logLabel()`, `label`, and `file` as `%s` args; pass the error as a trailing object/string arg. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
