### PR TITLE
Potential fix for code scanning alert no. 16: Insecure randomness

### DIFF
--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -1,6 +1,7 @@
 import type { Server, Socket } from 'socket.io'
 import type { ClientToServerEvents, ServerToClientEvents, TokenUsage, ResolvedPolicy, AgentMode, ChainApprovalMode, UserRole } from '@rondoflow/shared'
 import { hasMinRole, normalizeRole, ANTHROPIC, TIMEOUTS } from '@rondoflow/shared'
+import { randomBytes } from 'crypto'
 import { prisma } from '../lib/prisma'
 import { ProcessManager } from '../engine/process-manager'
 import { buildSpawnConfig } from '../engine/prompt-builder'
@@ -1332,7 +1333,7 @@ async function handleChainExecute(
   io: Server<ClientToServerEvents, ServerToClientEvents>,
   data: { chainId?: string; definition: ChainDefinitionPayload; initialMessage: string; workspaceId?: string; director?: boolean; directorRigor?: number; directorCustomInstructions?: string; planner?: boolean; plannerCustomInstructions?: string; approvalMode?: ChainApprovalMode },
 ): Promise<void> {
-  const chainId = data.chainId ?? `chain-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const chainId = data.chainId ?? `chain-${Date.now()}-${randomBytes(4).toString('hex')}`
   const room = socketRoom(socket)
 
   // Viewers are read-only — reject before any state lookup/emit.


### PR DESCRIPTION
Potential fix for [https://github.com/rondoflow/rondoflow/security/code-scanning/16](https://github.com/rondoflow/rondoflow/security/code-scanning/16)

Use a cryptographically secure random source for the generated `chainId` suffix instead of `Math.random()`.  
Best fix in this file: replace the fallback `chainId` construction in `handleChainExecute` (line 1335 region) with `randomBytes` from Node’s built-in `crypto` module, e.g. 4 bytes hex (`8` chars) to preserve similar ID shape/length and functionality.

Changes needed in `packages/server/src/socket/handlers.ts`:
- Add a new import: `import { randomBytes } from 'crypto'`.
- Replace:
  - `` `chain-${Date.now()}-${Math.random().toString(36).slice(2, 8)}` ``
  - with:
  - `` `chain-${Date.now()}-${randomBytes(4).toString('hex')}` ``

No other logic changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
